### PR TITLE
Updated version of hapi, bell, hoek, hapi-auth-cookie.  gets isLoggedIn working.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   "author": "Santhosh Nageshwar <santhoshbabun@gmail.com>",
   "license": "BSD",
   "dependencies": {
-    "hapi": "~6.0.2",
+    "hapi": "~6.3.0",
     "bell": "~1.0.2",
     "joi": "~4.6.1",
     "lout": "~5.0.1",
-    "hoek": "~2.3.0",
-    "hapi-auth-cookie": "~1.2.0",
+    "hoek": "~2.4.0",
+    "hapi-auth-cookie": "~1.3.0",
     "confidence": "~0.12.1",
     "handlebars": "~2.0.0-alpha.4"
   }

--- a/plugins/auth/auth.js
+++ b/plugins/auth/auth.js
@@ -4,18 +4,18 @@ var Providers = require("./config").get('/provider');
 
 exports.register = function(plugin, options, next) {
 
-    //app cache to store user information once loggedin.
+    //app cache to store user information once logged in.
     var cache = plugin.cache({
         expiresIn: 3 * 24 * 60 * 60 * 1000
     });
     plugin.app.cache = cache;
 
-    //Bind the object to the plugin to be accesible in handlers
+    //Bind the object to the plugin to be accessible in handlers
     plugin.bind({
         cache: plugin.app.cache
     });
     
-    //Add Multiple stratergies here and we have used confidence to pick up the configuration.
+    //Add Multiple strategies here and we have used confidence to pick up the configuration.
     plugin.auth.strategy('facebook', 'bell', Providers.facebook);
 
     plugin.auth.strategy('google', 'bell', Providers.google);

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -1,0 +1,10 @@
+<header id="header">
+    <h1><a href="/">Auth Hapily</a></h1>
+    <div class="auth-btns">
+        <div class="auth-btn fb">
+            <a href="/myprofile">
+                <span class="msg sm">View My Profile</span>
+            </a>
+        </div>
+    </div>
+</header>


### PR DESCRIPTION
I would like to thank you for your example - saved me a lot of head scratching :)
I had started on doing an example with these two plugins only a few hours ago, and found your example when I was looking for more information.
I hope this update is of interest to you. 

Updated server and cookie plugin support a route specific redirectTo false so isLoggedIn is available and correct rendering route /.
Added isLoggedIn to template rendering context.
Added nav.html for the isLoggedIn case.
Moved lout require down to register of plugins like other plugins.
Fixed a few spelling errors.
