### PR TITLE
Fix error handling in saving of session data

### DIFF
--- a/plugins/auth/handlers.js
+++ b/plugins/auth/handlers.js
@@ -8,7 +8,7 @@ exports.sessionManagement = function(request, reply) {
         account: account
     }, 0, function(err) {
         if (err) {
-            reply(err);
+            return reply(err);
         }
         request.auth.session.set({
             sid: sid


### PR DESCRIPTION
Hey!

Thanks for making this repo available. I have used it as an inspiration when doing auth with hapi and bell. 

Just stumbled upon this bug which is very unlikely to happen if you use the cache plugin (as you do), but may very well happen if you use some other cache backend. Since the function is not returning after replying about the error, one might end up with this:

```
Debug: internal, implementation, error 
    Error: reply interface called twice
    at ...stack trace
```

Thanks again for posting your code, and have a great day!
